### PR TITLE
Add audio sink detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The project now focuses on streaming voice data directly from your microphone. A
 - `MIMOStream` simulator generating bit vectors.
 - `SimpleNeuralNet` for quick experimentation.
 - Rust library `streamz-rs` for live microphone streaming through a small neural network.
+- Automatically selects the available PulseAudio or ALSA sink on Linux.
 - Example program demonstrating live streaming from the microphone.
 
 ## Requirements
@@ -30,6 +31,7 @@ cargo run --example live_stream --manifest-path streamz-rs/Cargo.toml
 ```
 
 The example listens to your microphone and plays the processed signal continuously.
+On Linux, the library automatically chooses PulseAudio or ALSA depending on what is available.
 
 ## License
 


### PR DESCRIPTION
## Summary
- detect PulseAudio vs ALSA with a helper function
- pick ALSA host if available
- print detected backend when running examples
- document automatic backend detection in README

## Testing
- `cargo test --manifest-path streamz-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684a3cff68f48323a6b8853f0ee25f79