### PR TITLE
Fix build failure due to missing ALSA dev libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ The project now focuses on streaming voice data directly from your microphone. A
 ## Requirements
 
 - Rust 1.70+ and Cargo.
+- On Linux, the `libasound2-dev` package is required to build the ALSA backend
+  used by the `rodio` and `cpal` crates. Install it via `apt`:
+
+```bash
+sudo apt-get install libasound2-dev
+```
 
 Build the example with:
 


### PR DESCRIPTION
## Summary
- document requirement to install `libasound2-dev` for Linux builds

## Testing
- `cargo build`

------
https://chatgpt.com/codex/tasks/task_e_684a3f754dc08323a12b674ecea917c2