### PR TITLE
Fix zero output by randomizing weights

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ Run the live streaming program:
 ```
 
 The program listens to your microphone and plays the processed signal continuously.
+If you do not hear any output, ensure your audio devices are recognized and the
+`libasound2-dev` package is installed on Linux. The neural network now starts
+with random weights so it immediately produces a non-zero signal.
 Audio output uses ALSA on Linux.
 
 ## License

--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -83,10 +83,13 @@ pub struct SimpleNeuralNet {
 impl SimpleNeuralNet {
     /// Create a new network with the given layer sizes
     pub fn new(input: usize, hidden: usize, output: usize) -> Self {
+        use rand::distributions::Uniform;
+        let mut rng = rand::thread_rng();
+        let dist = Uniform::new(-0.5, 0.5);
         Self {
-            w1: Array2::zeros((input, hidden)),
+            w1: Array2::from_shape_fn((input, hidden), |_| rng.sample(dist)),
             b1: Array1::zeros(hidden),
-            w2: Array2::zeros((hidden, output)),
+            w2: Array2::from_shape_fn((hidden, output), |_| rng.sample(dist)),
             b2: Array1::zeros(output),
         }
     }


### PR DESCRIPTION
## Summary
- use random weights for `SimpleNeuralNet` so audio output isn't zero
- mention random initialization in README troubleshooting section

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684a47343b048323937db3bb937f69fb