### PR TITLE
Add live voice training

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Run the live streaming program:
 ```
 
 The program listens to your microphone and plays the processed signal continuously.
+On startup it records a few seconds of your speech and uses that sample to pretrain
+the neural network so the output more closely matches your voice.
 If you do not hear any output, ensure your audio devices are recognized and the
 `libasound2-dev` package is installed on Linux. The neural network now starts
 with random weights so it immediately produces a non-zero signal.


### PR DESCRIPTION
## Summary
- record a short voice sample from the mic
- pretrain the network with that sample before streaming
- document the live training step in README

## Testing
- `cargo build --manifest-path streamz-rs/Cargo.toml` *(fails: `alsa` system library missing)*
- `cargo test --manifest-path streamz-rs/Cargo.toml` *(fails: `alsa` system library missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a48df77188323b74b74453fc636d9