### PR TITLE
Add sentence cycling during initial training

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ Run the live streaming program:
 
 The program listens to your microphone and plays the processed signal continuously.
 On startup it records a few seconds of your speech and uses that sample to pretrain
-the neural network so the output more closely matches your voice.
+the neural network so the output more closely matches your voice. After this
+initial step the program will prompt you to read a series of built‑in sentences.
+Each sentence is recorded and immediately used for training. The list is cycled
+once before streaming begins.
 If you do not hear any output, ensure your audio devices are recognized and the
 `libasound2-dev` package is installed on Linux. The neural network now starts
 with random weights so it immediately produces a non-zero signal.


### PR DESCRIPTION
## Summary
- allow multiple cycles over the prompt list when training
- update live streaming code to specify number of sentence cycles
- document the sentence prompts in the README

## Testing
- `cargo test --quiet` *(fails: alsa-sys build-script requires system library)*

------
https://chatgpt.com/codex/tasks/task_e_684a552dd6508323939a21144e3f8747