### PR TITLE
Remove initial recording phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ Run the live streaming program:
 ```
 
 The program listens to your microphone and plays the processed signal continuously.
-On startup it records a few seconds of your speech and uses that sample to pretrain
-the neural network so the output more closely matches your voice. After this
-initial step the program will prompt you to read a series of built‑in sentences.
-Each sentence is recorded and immediately used for training. The list is cycled
-once before streaming begins.
+When it starts you will be prompted to read a series of built‑in sentences.
+Each sentence is recorded once your voice rises above the detected noise level
+and immediately used for training. The list is cycled once before streaming
+begins.
 If you do not hear any output, ensure your audio devices are recognized and the
 `libasound2-dev` package is installed on Linux. The neural network now starts
 with random weights so it immediately produces a non-zero signal.

--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -333,13 +333,7 @@ pub fn live_mic_stream(net: Arc<Mutex<SimpleNeuralNet>>) -> Result<(), Box<dyn E
 
     let err_fn = |err| eprintln!("Stream error: {}", err);
 
-    println!("Recording your voice for 3 seconds...");
-    let samples = record_voice_sample(3)?;
-    {
-        let mut net_lock = net.lock().unwrap();
-        pretrain_network(&mut net_lock, &samples, 1, 0.001);
-    }
-    println!("Initial training complete.");
+    println!("Beginning training. Please read each sentence after the prompt.");
 
     const PROMPTS: [&str; 15] = [
         "The quick brown fox jumps over the lazy dog.",


### PR DESCRIPTION
## Summary
- start training with the built-in sentences instead of a 3‑second sample
- update instructions in README

## Testing
- `cargo test --quiet` *(fails: alsa library not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a56cfc2a8832397fe9a4135e38758