### PR TITLE
Improve audio noise handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The project now focuses on streaming voice data directly from your microphone. A
 - Uses ALSA for audio output on Linux.
 - Command line program demonstrating live streaming from the microphone.
 - Noise gate threshold adjustable in real time using the Up and Down arrow keys.
+- Ambient noise baseline is subtracted from incoming audio so training focuses on clean voice samples.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- subtract captured ambient noise baseline from incoming audio
- filter processed samples when recording training sentences
- apply baseline subtraction in live streaming pipeline
- document ambient noise baseline subtraction in README

## Testing
- `cargo test --manifest-path streamz-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684a5d7d712c8323ad25c98652a38afd