### PR TITLE
Switch neural network to floating point audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The project now focuses on streaming voice data directly from your microphone. A
 
 - `MIMOStream` simulator generating bit vectors.
 - `SimpleNeuralNet` for quick experimentation.
+- Samples are normalized to floating point values before neural processing.
 - Rust library `streamz-rs` for live microphone streaming through a small neural network.
 - Uses ALSA for audio output on Linux.
 - Command line program demonstrating live streaming from the microphone.

--- a/streamz-rs/examples/live_stream.rs
+++ b/streamz-rs/examples/live_stream.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use streamz_rs::{live_mic_stream, SimpleNeuralNet};
 
 fn main() {
-    let net = Arc::new(Mutex::new(SimpleNeuralNet::new(16, 8, 16)));
+    let net = Arc::new(Mutex::new(SimpleNeuralNet::new(1, 8, 1)));
     if let Err(e) = live_mic_stream(net) {
         eprintln!("Error: {}", e);
     }

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -2,7 +2,7 @@ use std::sync::{Arc, Mutex};
 use streamz_rs::{live_mic_stream, SimpleNeuralNet};
 
 fn main() {
-    let net = Arc::new(Mutex::new(SimpleNeuralNet::new(16, 8, 16)));
+    let net = Arc::new(Mutex::new(SimpleNeuralNet::new(1, 8, 1)));
     if let Err(e) = live_mic_stream(net) {
         eprintln!("Error: {}", e);
     }


### PR DESCRIPTION
## Summary
- keep microphone samples as floating point values for neural network
- convert network output back to i16 for rodio playback
- default network is 1->8->1 instead of bit-based 16->8->16
- document float normalization in the README

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684aa3d702d88323bb00565ba3e48556