### PR TITLE
Improve speaker identification

### DIFF
--- a/streamz-rs/examples/live_stream.rs
+++ b/streamz-rs/examples/live_stream.rs
@@ -1,9 +1,9 @@
 use std::sync::{Arc, Mutex};
-use streamz_rs::{live_mic_stream, SimpleNeuralNet};
+use streamz_rs::{live_mic_stream, SimpleNeuralNet, WINDOW_SIZE};
 
 fn main() {
-    let net = Arc::new(Mutex::new(SimpleNeuralNet::new(1, 8, 1)));
-    if let Err(e) = live_mic_stream(net) {
+    let net = Arc::new(Mutex::new(SimpleNeuralNet::new(WINDOW_SIZE, 32, 1)));
+    if let Err(e) = live_mic_stream(net, 1) {
         eprintln!("Error: {}", e);
     }
 }

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -1,6 +1,7 @@
 use std::io::{self, Write};
 use streamz_rs::{
     identify_speaker, load_wav_samples, train_from_files, SimpleNeuralNet,
+    WINDOW_SIZE,
 };
 
 const TRAIN_FILES: [(&str, usize); 6] = [
@@ -15,7 +16,7 @@ const TRAIN_FILES: [(&str, usize); 6] = [
 const NUM_SPEAKERS: usize = 2;
 
 fn main() {
-    let mut net = SimpleNeuralNet::new(1, 8, NUM_SPEAKERS);
+    let mut net = SimpleNeuralNet::new(WINDOW_SIZE, 32, NUM_SPEAKERS);
     if let Err(e) = train_from_files(&mut net, &TRAIN_FILES, NUM_SPEAKERS, 1, 0.001) {
         eprintln!("Training failed: {}", e);
         return;


### PR DESCRIPTION
## Summary
- handle larger windowed inputs for better training
- update network configuration for windowed feature vectors
- patch example live_stream

## Testing
- `cargo check`
- `cargo test --quiet`
- `cargo build --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684ad0572ce48323a7abc924ae143439