### PR TITLE
Add automatic WAV spec detection

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -1,7 +1,6 @@
 use std::io::{self, Write};
 use streamz_rs::{
-    identify_speaker, load_wav_samples, train_from_files, SimpleNeuralNet,
-    WINDOW_SIZE,
+    identify_speaker, load_wav_samples, train_from_files, SimpleNeuralNet, WINDOW_SIZE,
 };
 
 const TRAIN_FILES: [(&str, usize); 6] = [


### PR DESCRIPTION
## Summary
- infer dataset sample rate/bit depth before training
- print detected WAV specs and error on mismatch

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ad2aaed9c8323a1e9cb60e606a4f7