### PR TITLE
Improve training for better speaker recognition

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -51,7 +51,20 @@ fn window_samples(samples: &[i16]) -> Vec<Vec<f32>> {
     samples
         .chunks(WINDOW_SIZE)
         .filter(|c| c.len() == WINDOW_SIZE)
-        .map(|c| c.iter().map(|&s| i16_to_f32(s)).collect())
+        .map(|c| {
+            let floats: Vec<f32> = c.iter().map(|&s| i16_to_f32(s)).collect();
+            let mean = floats.iter().copied().sum::<f32>() / floats.len() as f32;
+            let var = floats
+                .iter()
+                .map(|&v| {
+                    let d = v - mean;
+                    d * d
+                })
+                .sum::<f32>()
+                / floats.len() as f32;
+            let std = var.sqrt().max(1e-6);
+            floats.iter().map(|&v| (v - mean) / std).collect()
+        })
         .collect()
 }
 

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -16,7 +16,9 @@ const NUM_SPEAKERS: usize = 2;
 
 fn main() {
     let mut net = SimpleNeuralNet::new(WINDOW_SIZE, 32, NUM_SPEAKERS);
-    if let Err(e) = train_from_files(&mut net, &TRAIN_FILES, NUM_SPEAKERS, 1, 0.001) {
+    // Train longer and with a slightly higher learning rate so the tiny
+    // dataset actually influences the model weights.
+    if let Err(e) = train_from_files(&mut net, &TRAIN_FILES, NUM_SPEAKERS, 30, 0.01) {
         eprintln!("Training failed: {}", e);
         return;
     }


### PR DESCRIPTION
## Summary
- normalize each training window by mean and std deviation
- train for more epochs with a higher learning rate

## Testing
- `cargo test --lib --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684adac020408323837604d483168e91