### PR TITLE
Auto detect speaker count

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -12,37 +12,65 @@ const TRAIN_FILES: [(&str, usize); 6] = [
     ("examples/training_data/arctic_b0417.wav", 1),
 ];
 
-const NUM_SPEAKERS: usize = 2;
+/// Determine the number of speakers based on the TRAIN_FILES array.
+/// The highest class index is assumed to be the last speaker and
+/// speaker indexing starts at 0.
+fn count_speakers() -> usize {
+    TRAIN_FILES
+        .iter()
+        .map(|&(_, class)| class)
+        .max()
+        .map(|max| max + 1)
+        .unwrap_or(0)
+}
 
 fn main() {
-    let mut net = SimpleNeuralNet::new(WINDOW_SIZE, 32, NUM_SPEAKERS);
+    let num_speakers = count_speakers();
+    let mut net = SimpleNeuralNet::new(WINDOW_SIZE, 32, num_speakers);
     // Train longer and with a slightly higher learning rate so the tiny
     // dataset actually influences the model weights.
-    if let Err(e) = train_from_files(&mut net, &TRAIN_FILES, NUM_SPEAKERS, 30, 0.01) {
+    if let Err(e) = train_from_files(&mut net, &TRAIN_FILES, num_speakers, 30, 0.01) {
         eprintln!("Training failed: {}", e);
         return;
     }
     println!("Training complete. Choose a speaker file to test:");
-    println!("[1] Speaker 1");
-    println!("[2] Speaker 2");
+
+    // Pick one example file per speaker for testing prompts
+    let mut sample_for_speaker: Vec<Option<&str>> = vec![None; num_speakers];
+    for &(path, class) in &TRAIN_FILES {
+        if class < num_speakers && sample_for_speaker[class].is_none() {
+            sample_for_speaker[class] = Some(path);
+        }
+    }
+    for (i, sample) in sample_for_speaker.iter().enumerate() {
+        if sample.is_some() {
+            println!("[{}] Speaker {}", i + 1, i + 1);
+        }
+    }
     print!("> ");
     io::stdout().flush().unwrap();
     let mut input = String::new();
     if io::stdin().read_line(&mut input).is_err() {
         return;
     }
-    let path = match input.trim() {
-        "1" => "examples/training_data/arctic_a0008.wav",
-        "2" => "examples/training_data/arctic_b0196.wav",
+    let choice: usize = match input.trim().parse() {
+        Ok(n) if n >= 1 && n <= num_speakers => n,
         _ => {
             println!("Invalid selection");
+            return;
+        }
+    };
+    let path = match sample_for_speaker[choice - 1] {
+        Some(p) => p,
+        None => {
+            println!("No sample for selected speaker");
             return;
         }
     };
     match load_wav_samples(path) {
         Ok(samples) => {
             let speaker = identify_speaker(&net, &samples);
-            println!("Model prediction: Speaker {}", speaker);
+            println!("Model prediction: Speaker {}", speaker + 1);
         }
         Err(e) => eprintln!("Failed to load test file: {}", e),
     }


### PR DESCRIPTION
## Summary
- detect the number of speakers from the training file table
- list selectable speakers dynamically
- report predictions as 1-indexed

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_684ade4f49d0832387ea2e0b98992b30