### PR TITLE
Fix model load path

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -206,13 +206,13 @@ impl SimpleNeuralNet {
     pub fn load(path: &str) -> Result<Self, Box<dyn Error>> {
         let file = File::open(path)?;
         let mut npz = NpzReader::new(file)?;
-        let sample_rate: ndarray::Array1<i64> = npz.by_name("sample_rate.npy")?;
-        let bits: ndarray::Array1<i64> = npz.by_name("bits.npy")?;
+        let sample_rate: ndarray::Array1<i64> = npz.by_name("sample_rate")?;
+        let bits: ndarray::Array1<i64> = npz.by_name("bits")?;
         Ok(Self {
-            w1: npz.by_name("w1.npy")?,
-            b1: npz.by_name("b1.npy")?,
-            w2: npz.by_name("w2.npy")?,
-            b2: npz.by_name("b2.npy")?,
+            w1: npz.by_name("w1")?,
+            b1: npz.by_name("b1")?,
+            w2: npz.by_name("w2")?,
+            b2: npz.by_name("b2")?,
             sample_rate: sample_rate[0] as u32,
             bits: bits[0] as u16,
         })

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -32,7 +32,7 @@ fn count_speakers() -> usize {
 
 fn main() {
     let num_speakers = count_speakers();
-    let mut net = if Path::new(MODEL_PATH).exists() {
+    let net = if Path::new(MODEL_PATH).exists() {
         match SimpleNeuralNet::load(MODEL_PATH) {
             Ok(n) => {
                 println!("Loaded saved model from {}", MODEL_PATH);


### PR DESCRIPTION
## Summary
- fix `SimpleNeuralNet::load` to read files without `.npy` suffix
- remove unused `mut` from `main`

## Testing
- `cargo build --quiet`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ae2954000832390ac70ef1aa2f6af