### PR TITLE
Update training file management

### DIFF
--- a/streamz-rs/Cargo.toml
+++ b/streamz-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "streamz-rs"
 version = "0.1.0"
 edition = "2021"
-build = "build.rs"
+# build.rs no longer needed
 
 [dependencies]
 ndarray = "0.15"

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -1,48 +1,80 @@
+use std::fs;
 use std::io::{self, Write};
 use std::path::Path;
-use std::time::Duration;
-use crossterm::event::{self, Event, KeyCode};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use streamz_rs::{
     identify_speaker, load_wav_samples, train_from_files, SimpleNeuralNet, WINDOW_SIZE,
 };
 
-include!(concat!(env!("OUT_DIR"), "/train_files.rs"));
 
 const MODEL_PATH: &str = "model.npz";
 const TRAIN_FILE_LIST: &str = "train_files.txt";
 
-fn write_train_files(path: &str, files: &[(&str, usize)]) {
+fn load_train_files(path: &str) -> Vec<(String, usize)> {
+    if let Ok(content) = fs::read_to_string(path) {
+        content
+            .lines()
+            .filter_map(|line| {
+                let mut parts = line.split(',');
+                if let (Some(p), Some(c)) = (parts.next(), parts.next()) {
+                    c.trim().parse::<usize>().ok().map(|cls| (p.trim().into(), cls))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        vec![
+            ("examples/training_data/arctic_a0008.wav".into(), 0),
+            ("examples/training_data/arctic_a0015.wav".into(), 0),
+            ("examples/training_data/arctic_a0021.wav".into(), 0),
+            ("examples/training_data/arctic_b0196.wav".into(), 1),
+            ("examples/training_data/arctic_b0356.wav".into(), 1),
+            ("examples/training_data/arctic_b0417.wav".into(), 1),
+        ]
+    }
+}
+
+fn write_train_files(path: &str, files: &[(String, usize)]) {
     if let Ok(mut f) = std::fs::File::create(path) {
-        for &(p, c) in files {
+        for (p, c) in files {
             let _ = writeln!(f, "{},{}", p, c);
         }
     }
 }
 
-fn rebuild_project() {
-    if let Ok(mut child) = std::process::Command::new("cargo")
-        .args(&["build", "--release"])
-        .spawn()
-    {
-        let _ = child.wait();
+fn relabel_files(
+    net: &SimpleNeuralNet,
+    files: &mut [(String, usize)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    for (path, class) in files.iter_mut() {
+        let samples = load_wav_samples(path)?;
+        let pred = identify_speaker(net, &samples);
+        *class = pred;
     }
+    Ok(())
 }
 
-/// Determine the number of speakers based on the TRAIN_FILES array.
-/// The highest class index is assumed to be the last speaker and
-/// speaker indexing starts at 0.
-fn count_speakers() -> usize {
-    TRAIN_FILES
+
+/// Determine the number of speakers based on the provided training list.
+/// The highest class index is assumed to be the last speaker and speaker
+/// indexing starts at 0.
+fn count_speakers(files: &[(String, usize)]) -> usize {
+    files
         .iter()
-        .map(|&(_, class)| class)
+        .map(|(_, class)| *class)
         .max()
         .map(|max| max + 1)
         .unwrap_or(0)
 }
 
 fn main() {
-    let num_speakers = count_speakers();
+    let mut train_files = load_train_files(TRAIN_FILE_LIST);
+    let num_speakers = count_speakers(&train_files);
+    let train_refs: Vec<(&str, usize)> = train_files
+        .iter()
+        .map(|(p, c)| (p.as_str(), *c))
+        .collect();
+
     let net = if Path::new(MODEL_PATH).exists() {
         match SimpleNeuralNet::load(MODEL_PATH) {
             Ok(n) => {
@@ -52,38 +84,40 @@ fn main() {
             Err(e) => {
                 eprintln!("Failed to load model: {}. Retraining...", e);
                 let mut n = SimpleNeuralNet::new(WINDOW_SIZE, 32, num_speakers);
-                if let Err(e) = train_from_files(&mut n, &TRAIN_FILES, num_speakers, 30, 0.01) {
+                if let Err(e) = train_from_files(&mut n, &train_refs, num_speakers, 30, 0.01) {
                     eprintln!("Training failed: {}", e);
                     return;
                 }
                 if let Err(e) = n.save(MODEL_PATH) {
                     eprintln!("Failed to save model: {}", e);
                 }
-                write_train_files(TRAIN_FILE_LIST, &TRAIN_FILES);
-                rebuild_project();
                 n
             }
         }
     } else {
         let mut n = SimpleNeuralNet::new(WINDOW_SIZE, 32, num_speakers);
-        if let Err(e) = train_from_files(&mut n, &TRAIN_FILES, num_speakers, 30, 0.01) {
+        if let Err(e) = train_from_files(&mut n, &train_refs, num_speakers, 30, 0.01) {
             eprintln!("Training failed: {}", e);
             return;
         }
         if let Err(e) = n.save(MODEL_PATH) {
             eprintln!("Failed to save model: {}", e);
         }
-        write_train_files(TRAIN_FILE_LIST, &TRAIN_FILES);
-        rebuild_project();
         n
     };
+
+    if let Err(e) = relabel_files(&net, &mut train_files) {
+        eprintln!("Failed to relabel files: {}", e);
+    } else {
+        write_train_files(TRAIN_FILE_LIST, &train_files);
+    }
     println!("Model ready. Choose a speaker file to test:");
 
     // Pick one example file per speaker for testing prompts
     let mut sample_for_speaker: Vec<Option<&str>> = vec![None; num_speakers];
-    for &(path, class) in &TRAIN_FILES {
-        if class < num_speakers && sample_for_speaker[class].is_none() {
-            sample_for_speaker[class] = Some(path);
+    for (path, class) in &train_files {
+        if *class < num_speakers && sample_for_speaker[*class].is_none() {
+            sample_for_speaker[*class] = Some(path.as_str());
         }
     }
     for (i, sample) in sample_for_speaker.iter().enumerate() {
@@ -115,19 +149,6 @@ fn main() {
         Ok(samples) => {
             let speaker = identify_speaker(&net, &samples);
             println!("Model prediction: Speaker {}", speaker + 1);
-            println!("Press ESC to exit...");
-            if enable_raw_mode().is_ok() {
-                loop {
-                    if event::poll(Duration::from_millis(500)).unwrap_or(false) {
-                        if let Event::Key(key) = event::read().unwrap() {
-                            if key.code == KeyCode::Esc {
-                                break;
-                            }
-                        }
-                    }
-                }
-                let _ = disable_raw_mode();
-            }
         }
         Err(e) => eprintln!("Failed to load test file: {}", e),
     }


### PR DESCRIPTION
## Summary
- drop ESC key loop
- load training data at runtime instead of using generated constants
- remove automatic rebuild step
- write back corrected labels after running inference

## Testing
- `cargo test --manifest-path streamz-rs/Cargo.toml`

------
https://chatgpt.com/codex/tasks/task_e_684ae8a27f848323891c03b242f935fa