### PR TITLE
Adjust speaker identification confidence

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -9,7 +9,10 @@ use streamz_rs::{
 
 const MODEL_PATH: &str = "model.npz";
 const TRAIN_FILE_LIST: &str = "train_files.txt";
-const CONF_THRESHOLD: f32 = 0.6;
+/// Confidence threshold for assigning a sample to an existing speaker.
+/// Higher values make the program less eager to reuse a known speaker
+/// and instead create a new one when confidence is low.
+const CONF_THRESHOLD: f32 = 0.8;
 
 fn load_train_files(path: &str) -> Vec<(String, Option<usize>)> {
     if let Ok(content) = fs::read_to_string(path) {


### PR DESCRIPTION
## Summary
- tweak the confidence threshold used when matching training samples

## Testing
- `cargo build --release`
- `./target/release/StreamZ`

------
https://chatgpt.com/codex/tasks/task_e_684b2ab5625483239f2f2b7612941ea6