### PR TITLE
Fix speaker identification when only one known speaker

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -453,6 +453,12 @@ pub fn identify_speaker_with_threshold(
     sample: &[i16],
     threshold: f32,
 ) -> Option<usize> {
+    // If there's only a single speaker known, every prediction will trivially
+    // have a confidence of 1.0. In that case we should treat the result as
+    // "unknown" so new speakers can be added.
+    if net.output_size() <= 1 {
+        return None;
+    }
     let mut sums = vec![0.0f32; net.output_size()];
     let mut count = 0f32;
     for win in window_samples(sample) {


### PR DESCRIPTION
## Summary
- avoid false 100% confidence when the model only knows one speaker

## Testing
- `cargo build --release`
- `./target/release/StreamZ` on example data

------
https://chatgpt.com/codex/tasks/task_e_684b44c216948323a8494c5c73dd4d86