### PR TITLE
Improve threshold handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ StreamZ is a small Rust application that trains and executes a simple neural net
 - Feed‑forward neural network (`SimpleNeuralNet`) with one hidden layer and softmax output.
 - Training files and their assigned class numbers are stored in `train_files.txt` so that additional runs continue learning from where you left off.
 - Model weights, sample rate and other metadata are saved in `model.npz` for reuse between sessions.
-- Unlabelled files are compared against existing speakers using a confidence threshold; low confidence will create a new speaker entry automatically.
+- Unlabelled files are compared against existing speakers using a confidence threshold (default `0.8`); low confidence will create a new speaker entry automatically. The threshold can be overridden with `--threshold <value>` when running the program.
 - Works with recordings that use different sample rates and can grow to
   handle any number of speakers over time.
 - A helper function `identify_speaker_list` returns all detected speakers in


### PR DESCRIPTION
## Summary
- make confidence threshold configurable via a `--threshold` flag
- default threshold lowered to `0.8`
- document the threshold flag in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b47390c8883238db3ad6f9f42fc46