### PR TITLE
Add MFCC feature extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # StreamZ
 
-StreamZ is a small Rust application that trains and executes a simple neural network to classify short MP3 (or WAV) recordings by speaker.  The project demonstrates how to read raw audio, convert it into FFT feature windows and incrementally learn new speakers from a list of files.
+StreamZ is a small Rust application that trains and executes a simple neural network to classify short MP3 (or WAV) recordings by speaker.  The project demonstrates how to read raw audio, convert it into MFCC feature windows and incrementally learn new speakers from a list of files.
 
 ## Features
 
-- Loads MP3 or 16‑bit WAV files and automatically converts them into normalised FFT feature windows.
+- Loads MP3 or 16‑bit WAV files and automatically converts them into normalised MFCC feature windows.
 - Feed‑forward neural network (`SimpleNeuralNet`) with one hidden layer and softmax output.
 - Training files and their assigned class numbers are stored in `train_files.txt` so that additional runs continue learning from where you left off.
 - Model weights, sample rate and other metadata are saved in `model.npz` for reuse between sessions.

--- a/streamz-rs/Cargo.lock
+++ b/streamz-rs/Cargo.lock
@@ -118,31 +118,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -186,12 +161,6 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -256,6 +225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools-num"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a872a22f9e6f7521ca557660adb96dd830e54f0f490fa115bb55dd69d38b27e7"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +282,17 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "mel_filter"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "860a755112c02a5b64fa21c1d7f2eaedd4ac86d99457bd0eefe3b89d24b382ba"
+dependencies = [
+ "itertools-num",
+ "log",
+ "num-traits",
 ]
 
 [[package]]
@@ -615,26 +604,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +617,15 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "rustdct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b61555105d6a9bf98797c063c362a1d24ed8ab0431655e38f1cf51e52089551"
+dependencies = [
+ "rustfft",
+]
 
 [[package]]
 name = "rustfft"
@@ -750,11 +728,12 @@ dependencies = [
  "crossterm",
  "hound",
  "indicatif",
+ "mel_filter",
  "minimp3",
  "ndarray",
  "ndarray-npy",
  "rand",
- "rayon",
+ "rustdct",
  "rustfft",
  "tokio",
 ]

--- a/streamz-rs/Cargo.toml
+++ b/streamz-rs/Cargo.toml
@@ -16,8 +16,9 @@ ndarray-npy = "0.8"
 hound = "3"
 minimp3 = "0.5"
 indicatif = "0.17"
-rayon = "1.7"
 rustfft = "6"
+rustdct = "0.7"
+mel_filter = "0.1"
 
 [[bin]]
 name = "StreamZ"

--- a/streamz-rs/examples/live_stream.rs
+++ b/streamz-rs/examples/live_stream.rs
@@ -1,8 +1,8 @@
 // The live microphone streaming example is disabled because the audio
 // backend dependencies are not included.
-use streamz_rs::{SimpleNeuralNet, WINDOW_SIZE};
+use streamz_rs::{SimpleNeuralNet, FEATURE_SIZE};
 
 fn main() {
-    let _net = SimpleNeuralNet::new(WINDOW_SIZE, 32, 1);
+    let _net = SimpleNeuralNet::new(FEATURE_SIZE, 32, 1);
     println!("live_mic_stream example is not available in this build.");
 }


### PR DESCRIPTION
## Summary
- switch feature extraction from FFT to MFCC
- adjust README for MFCC features
- update example to use new feature size

## Testing
- `cargo check`
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684b51c863cc83239fca0dcf73ed2adb