### PR TITLE
Add cosine-similarity speaker recognition

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -644,3 +644,60 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         dot / (norm_a * norm_b)
     }
 }
+
+/// Compute an average embedding vector for every known speaker.
+/// Each speaker's embedding is the mean of embeddings for all recorded
+/// training files belonging to that speaker. Missing or unreadable files
+/// are skipped.
+pub fn compute_speaker_embeddings(net: &SimpleNeuralNet) -> Result<Vec<Vec<f32>>, Box<dyn Error>> {
+    let mut embeds = Vec::with_capacity(net.output_size());
+    for files in net.file_lists.iter().take(net.output_size()) {
+        let mut sum = vec![0.0f32; net.embedding_size()];
+        let mut count = 0f32;
+        for path in files {
+            if let Ok(samples) = load_audio_samples(path) {
+                let emb = extract_embedding(net, &samples);
+                for (i, v) in emb.iter().enumerate() {
+                    sum[i] += *v;
+                }
+                count += 1.0;
+            }
+        }
+        if count > 0.0 {
+            for v in &mut sum {
+                *v /= count;
+            }
+        }
+        embeds.push(sum);
+    }
+    Ok(embeds)
+}
+
+/// Identify a speaker by comparing an embedding against known speaker
+/// embeddings using cosine similarity. Returns `Some(index)` if the best
+/// similarity exceeds `threshold`.
+pub fn identify_speaker_cosine(
+    net: &SimpleNeuralNet,
+    speaker_embeds: &[Vec<f32>],
+    sample: &[i16],
+    threshold: f32,
+) -> Option<usize> {
+    if speaker_embeds.is_empty() {
+        return None;
+    }
+    let emb = extract_embedding(net, sample);
+    let mut best_idx = 0usize;
+    let mut best_val = f32::NEG_INFINITY;
+    for (idx, ref_vec) in speaker_embeds.iter().enumerate() {
+        let sim = cosine_similarity(ref_vec, &emb);
+        if sim > best_val {
+            best_val = sim;
+            best_idx = idx;
+        }
+    }
+    if best_val >= threshold {
+        Some(best_idx)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- compute and store speaker embeddings
- add cosine similarity based identification
- use new method during evaluation and training

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684b5e03c76483238110786c829b9c19