### PR TITLE
Implement simple learning rate decay

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -310,6 +310,7 @@ pub fn train_from_files(
             .unwrap(),
     );
 
+    let mut step = 0i32;
     for &(path, class) in files {
         pb.set_message(path.to_string());
         let (sample_rate, bits) = match audio_metadata(path) {
@@ -327,17 +328,19 @@ pub fn train_from_files(
         for _ in 0..epochs {
             match load_audio_samples(path) {
                 Ok(samples) => {
+                    let lr_scaled = lr * (0.99f32).powi(step);
                     let _ = pretrain_network(
                         net,
                         &samples,
                         class,
                         num_speakers,
                         1,
-                        lr,
+                        lr_scaled,
                         dropout,
                         batch_size,
                     );
                     net.record_training_file(class, path);
+                    step += 1;
                 }
                 Err(e) => {
                     eprintln!("Skipping {}: {}", path, e);

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -283,16 +283,21 @@ fn main() {
         pb.set_message(path.to_string());
         match result {
             Ok((_, _, samples)) => {
-                let dynamic_threshold = if loss_count < 50 { 0.95 } else { conf_threshold };
+                let dynamic_threshold = if loss_count < 50 {
+                    0.95
+                } else {
+                    conf_threshold
+                };
                 if let Some(label) = *class {
                     let sz = net.output_size();
+                    let lr = 0.01 * (0.99f32).powi(loss_count as i32);
                     let loss = pretrain_network(
                         &mut net,
                         &samples,
                         label,
                         sz,
                         TRAIN_EPOCHS,
-                        0.01,
+                        lr,
                         DROPOUT_PROB,
                         BATCH_SIZE,
                     );
@@ -304,13 +309,14 @@ fn main() {
                 {
                     *class = Some(pred);
                     let sz = net.output_size();
+                    let lr = 0.01 * (0.99f32).powi(loss_count as i32);
                     let loss = pretrain_network(
                         &mut net,
                         &samples,
                         pred,
                         sz,
                         TRAIN_EPOCHS,
-                        0.01,
+                        lr,
                         DROPOUT_PROB,
                         BATCH_SIZE,
                     );
@@ -323,13 +329,14 @@ fn main() {
                     let new_label = net.output_size() - 1;
                     *class = Some(new_label);
                     let sz = net.output_size();
+                    let lr = 0.01 * (0.99f32).powi(loss_count as i32);
                     let loss = pretrain_network(
                         &mut net,
                         &samples,
                         new_label,
                         sz,
                         TRAIN_EPOCHS,
-                        0.01,
+                        lr,
                         DROPOUT_PROB,
                         BATCH_SIZE,
                     );


### PR DESCRIPTION
## Summary
- decay the learning rate after each batch during main training
- apply a similar decay when using `train_from_files`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684b8a49d1008323a80dea28db667ebf