### PR TITLE
Increase MFCC dims and network size

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -186,7 +186,7 @@ fn main() {
             .map(|(p, c)| (p.as_str(), *c))
             .collect();
         let mut net =
-            SimpleNeuralNet::new(FEATURE_SIZE, 256, 128, count_speakers(&train_files).max(1));
+            SimpleNeuralNet::new(FEATURE_SIZE, 512, 256, count_speakers(&train_files).max(1));
         if !train_refs.is_empty() {
             let out_sz = net.output_size();
             let _ = train_from_files(
@@ -265,7 +265,7 @@ fn main() {
             }
             Err(e) => {
                 eprintln!("Failed to load model: {}", e);
-                SimpleNeuralNet::new(FEATURE_SIZE, 256, 128, num_speakers.max(1))
+                SimpleNeuralNet::new(FEATURE_SIZE, 512, 256, num_speakers.max(1))
             }
         }
     } else {
@@ -273,7 +273,7 @@ fn main() {
             num_speakers = 1;
             train_files[0].1 = Some(0);
         }
-        let mut n = SimpleNeuralNet::new(FEATURE_SIZE, 256, 128, num_speakers.max(1));
+        let mut n = SimpleNeuralNet::new(FEATURE_SIZE, 512, 256, num_speakers.max(1));
         let train_refs: Vec<(&str, usize)> = train_files
             .iter()
             .filter_map(|(p, c)| c.map(|cls| (p.as_str(), cls)))


### PR DESCRIPTION
## Summary
- expand MFCC feature dimension from 13 to 20 and update FEATURE_SIZE
- apply stronger audio augmentation with random time shift
- enlarge network hidden layers to (512, 256)

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684b90bf0bac8323ba908b671a187bcc