### PR TITLE
Improve audio preprocessing concurrency

### DIFF
--- a/streamz-rs/Cargo.lock
+++ b/streamz-rs/Cargo.lock
@@ -836,6 +836,7 @@ dependencies = [
  "minimp3",
  "ndarray",
  "ndarray-npy",
+ "once_cell",
  "rand",
  "rayon",
  "realfft 0.3.0",

--- a/streamz-rs/Cargo.toml
+++ b/streamz-rs/Cargo.toml
@@ -22,6 +22,7 @@ mel_filter = "0.1"
 rubato = "0.13"
 realfft = "0.3"
 rayon = "1.7"
+once_cell = "1"
 
 [[bin]]
 name = "StreamZ"


### PR DESCRIPTION
## Summary
- share FFT resampler instances across threads
- decode/resample all files in parallel before training
- use resampled audio map during the main training loop
- add `once_cell` dependency

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684bac724c0c83239e9b180555caf60b