### PR TITLE
Fix duplicate Ordering import

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -19,9 +19,8 @@ use std::error::Error;
 use std::fs::File;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use std::sync::atomic::{AtomicI32, Ordering};
+use std::sync::atomic::{AtomicI32, AtomicBool, Ordering};
 use once_cell::sync::Lazy;
-use std::sync::atomic::{AtomicBool, Ordering};
 
 pub const DEFAULT_SAMPLE_RATE: u32 = 44100;
 pub const WINDOW_SIZE: usize = 800;


### PR DESCRIPTION
## Summary
- deduplicate Ordering import in lib.rs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684bb3f0782c8323acaf3a13286ebb35