### PR TITLE
Remove redundant model save during processing

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -496,14 +496,6 @@ fn main() {
                     update_embeddings.store(true, Ordering::SeqCst);
                 }
             }
-
-            // Save periodically
-            if loss_count.load(Ordering::SeqCst) % 10 == 0 {
-                if let Err(e) = net.save(MODEL_PATH) {
-                    eprintln!("Failed to save model: {}", e);
-                }
-                *embeds = compute_speaker_embeddings(&net, &extractor).unwrap_or_default();
-            }
         } else {
             eprintln!("Missing audio for {}", path);
         }


### PR DESCRIPTION
## Summary
- reduce I/O by removing periodic `net.save` calls from the training loop

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684bbf17cdf48323bca47945fab1fc1a