### PR TITLE
Add burn-in and debugging output

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -1235,6 +1235,10 @@ pub fn identify_speaker_cosine(
             continue;
         }
         let accept_threshold = (mean_sim + *std_sim).max(threshold);
+        eprintln!(
+            "Speaker {}: sim = {:.4}, mean_sim = {:.4}, std = {:.4}, threshold = {:.4}",
+            i, sim, mean_sim, std_sim, accept_threshold
+        );
         if sim >= accept_threshold && sim > best_val {
             best_val = sim;
             best_idx = Some(i);
@@ -1262,6 +1266,10 @@ pub fn identify_speaker_cosine_feats(
             continue;
         }
         let accept_threshold = (mean_sim + *std_sim).max(threshold);
+        eprintln!(
+            "Speaker {}: sim = {:.4}, mean_sim = {:.4}, std = {:.4}, threshold = {:.4}",
+            i, sim, mean_sim, std_sim, accept_threshold
+        );
         if sim >= accept_threshold && sim > best_val {
             best_val = sim;
             best_idx = Some(i);


### PR DESCRIPTION
## Summary
- lower early threshold to 0.5 and implement burn‑in logic
- skip clips that have fewer than five windows
- log embedding counts and match decisions
- print per‑speaker cosine similarities for debugging

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d3c1b3614832382c093a104aa2da2