### PR TITLE
Refactor locking and add deadlock detection

### DIFF
--- a/streamz-rs/Cargo.lock
+++ b/streamz-rs/Cargo.lock
@@ -200,6 +200,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,10 +249,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+
+[[package]]
 name = "hound"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indicatif"
@@ -495,10 +523,13 @@ version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
+ "backtrace",
  "cfg-if",
  "libc",
+ "petgraph",
  "redox_syscall",
  "smallvec",
+ "thread-id",
  "windows-targets 0.52.6",
 ]
 
@@ -545,6 +576,16 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
 ]
 
 [[package]]
@@ -837,6 +878,7 @@ dependencies = [
  "ndarray",
  "ndarray-npy",
  "once_cell",
+ "parking_lot",
  "rand",
  "rayon",
  "realfft 0.3.0",
@@ -901,6 +943,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread-id"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/streamz-rs/Cargo.toml
+++ b/streamz-rs/Cargo.toml
@@ -23,6 +23,7 @@ rubato = "0.13.0"
 realfft = "0.3.0"
 rayon = "1.10.0"
 once_cell = "1.21.3"
+parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 
 [[bin]]
 name = "StreamZ"

--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -671,6 +671,7 @@ pub fn train_from_files(
 /// slightly "deeper" network without pulling in heavyweight dependencies we now
 /// include a second hidden layer. This keeps the code self contained while
 /// giving the model a bit more capacity.
+#[derive(Clone)]
 pub struct SimpleNeuralNet {
     w1: Array2<f32>,
     b1: Array1<f32>,


### PR DESCRIPTION
## Summary
- derive `Clone` for `SimpleNeuralNet`
- introduce `recompute_embeddings` helper for lock-free heavy work
- convert `speaker_features` to `RwLock`
- add deadlock detection thread
- update locking logic to use short-lived clones
- include parking_lot with deadlock detection feature

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d500378708323ba1e8bf32f8c101a