### PR TITLE
Fix speaker count calculation

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -1,7 +1,7 @@
 use hound;
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::env;
 use std::fs;
 use std::io::Write;
@@ -80,9 +80,8 @@ fn count_speakers(files: &[(String, Option<usize>)]) -> usize {
     files
         .iter()
         .filter_map(|(_, class)| *class)
-        .max()
-        .map(|max| max + 1)
-        .unwrap_or(0)
+        .collect::<HashSet<_>>()
+        .len()
 }
 
 /// Convert an MP3 file to a cached WAV if needed and return the new path.


### PR DESCRIPTION
## Summary
- count unique speaker IDs instead of using maximum label
- include `HashSet` to support counting

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d91fb66ec8323b5e02dc723be4783