### PR TITLE
Fix eval metrics with missing features

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -361,7 +361,15 @@ fn main() {
                 Err(_) => panic!("Arc has other references"),
             }
         };
+        let eval_set: Vec<(String, usize)> = eval_set
+            .into_iter()
+            .filter(|(p, _)| feature_map.contains_key(p))
+            .collect();
         let total = eval_set.len();
+        if total == 0 {
+            eprintln!("No features available for evaluation");
+            return;
+        }
         let pb = ProgressBar::new(total as u64);
         pb.set_style(
             ProgressStyle::default_bar()


### PR DESCRIPTION
## Summary
- skip evaluation files that failed feature extraction

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684d975dc9a88323a72da24292238d3e