### PR TITLE
Update training outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ either list are automatically converted to `cache/<name>.wav` before
 processing. If a neighbouring `.wav` file already exists it is used
 instead of creating a cached copy.
 
+After training completes, `target_files.txt` is automatically refreshed with
+the cached WAV paths and labels from `train_files.txt`. This lets running the
+program with `--eval` use the prepared evaluation list directly.
+
 Run the classifier:
 
 ```bash

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -74,6 +74,16 @@ fn write_train_files(path: &str, files: &[(String, Option<usize>)]) {
     }
 }
 
+fn write_target_files(path: &str, files: &[(String, Option<usize>)]) {
+    if let Ok(mut f) = std::fs::File::create(path) {
+        for (p, c) in files {
+            if let Some(cls) = c {
+                let _ = writeln!(f, "{},{}", p, cls);
+            }
+        }
+    }
+}
+
 fn load_target_files(path: &str) -> Vec<(String, usize)> {
     if let Ok(content) = fs::read_to_string(path) {
         let mut files = Vec::new();
@@ -688,6 +698,7 @@ fn main() {
     }
 
     write_train_files(TRAIN_FILE_LIST, &train_files);
+    write_target_files(TARGET_FILE_LIST, &train_files);
     println!("Updated training file labels:");
     for (p, c) in &train_files {
         match c {


### PR DESCRIPTION
## Summary
- generate cached target file list alongside training labels
- mention automatic target file generation in README

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684db1ef3a8c8323b61ae42dffaa76a9