### PR TITLE
Print saved embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ During the run every file listed in `train_files.txt` is processed.  If a line l
 - `--eval-split <fraction>` controls what fraction of labelled data is reserved for evaluation when `target_files.txt` is not present (default `0.2`).
 - `--force` retrains the model even when a saved model exists.
 - `--retrain` behaves like `--force` and can be used without `--eval`.
-- `--check-embeddings` loads `model.npz` and prints embedding quality metrics for the saved model.
+- `--check-embeddings` loads `model.npz` and prints quality metrics for any embeddings stored in the file. If none are saved it recomputes them from the training data.
 
 ## Feature Caching
 
@@ -97,7 +97,7 @@ greatly speeds up repeated training or evaluation on the same dataset.
   reused for faster startup.
 - Use `--eval` to measure model accuracy without updating weights.
 - `--eval-split <fraction>` sets the portion of labelled data reserved for evaluation when `target_files.txt` is absent.
-- `--check-embeddings` loads `model.npz` and prints embedding quality metrics for the saved model.
+- `--check-embeddings` loads `model.npz` and prints quality metrics for any embeddings stored in the file. If none are saved it recomputes them from the training data.
 
 ## Threaded Components
 

--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -223,6 +223,20 @@ fn recompute_embeddings(
 }
 
 fn print_embedding_quality(net: &SimpleNeuralNet, extractor: &FeatureExtractor) {
+    if !net.embeddings().is_empty() {
+        println!("Saved embeddings found in model.npz:");
+        let mut sum = 0.0f32;
+        for (i, (_mean, mean_sim, std_sim)) in net.embeddings().iter().enumerate() {
+            sum += *mean_sim;
+            println!(
+                "Speaker {}: mean similarity {:.4}, std dev {:.4}",
+                i, mean_sim, std_sim
+            );
+        }
+        println!("Average mean similarity: {:.4}", sum / net.embeddings().len() as f32);
+        return;
+    }
+
     match compute_speaker_embeddings(net, extractor) {
         Some(embeds) => {
             if embeds.is_empty() {


### PR DESCRIPTION
## Summary
- print any embeddings found in `model.npz` when running `--check-embeddings`
- update README to describe the behaviour

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e336c8b3c8323a4c280d25f1c2037