### PR TITLE
Fix embedding normalization

### DIFF
--- a/streamz-rs/src/lib.rs
+++ b/streamz-rs/src/lib.rs
@@ -932,8 +932,7 @@ impl SimpleNeuralNet {
     let x = arr1(input); // shape (60,)
     let h1 = Self::relu(&(self.w1.t().dot(&x) + &self.b1)); // shape (512,)
     let h2 = Self::relu(&(self.w2.t().dot(&h1) + &self.b2)); // shape (embedding_size,)
-    let mut vec = h2.to_vec();
-    normalize(&mut vec); // ensure cosine distance makes sense
+    let vec = h2.to_vec();
     vec
 }
 


### PR DESCRIPTION
## Summary
- avoid normalizing in `forward_embedding`
- keep normalization in `extract_embedding_from_features`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685442a45228832398fd508adbada4ad