### PR TITLE
Add training-based hidden encoding

### DIFF
--- a/streamz-rs/Cargo.lock
+++ b/streamz-rs/Cargo.lock
@@ -885,6 +885,7 @@ dependencies = [
  "rubato",
  "rustdct",
  "rustfft 6.4.0",
+ "sha2",
  "tokio",
 ]
 

--- a/streamz-rs/Cargo.toml
+++ b/streamz-rs/Cargo.toml
@@ -24,6 +24,7 @@ realfft = "0.3.0"
 rayon = "1.10.0"
 once_cell = "1.21.3"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
+sha2 = "0.10"
 
 [[bin]]
 name = "StreamZ"


### PR DESCRIPTION
## Summary
- convert checksum constant to hex string
- train network on constant bits with `encode_file`
- trigger encoding/decoding via `--encode` switch when special checksum is seen

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685625172a5c832394a67ff97e6c8b5e