### PR TITLE
Store hidden file in dedicated layer

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -666,10 +666,11 @@ fn main() {
             println!("Hiding {} in neural network", p);
             match encode_file(p) {
                 Ok(enc_net) => {
-                    let (w3, b3) = enc_net.output_layer();
-                    net.set_output_layer(w3, b3);
-                    if let Err(e) = net.save(MODEL_PATH) {
-                        eprintln!("Failed to save encoded model: {}", e);
+                    if let Some((w4, b4)) = enc_net.encoding_layer() {
+                        net.set_encoding_layer(w4, b4);
+                    } else {
+                        let (w3, b3) = enc_net.output_layer();
+                        net.set_encoding_layer(w3, b3);
                     }
                 }
                 Err(e) => eprintln!("Encoding failed: {}", e),


### PR DESCRIPTION
## Summary
- introduce optional w4/b4 encoding layer in `SimpleNeuralNet`
- load/save w4_*/b4_* arrays
- expose `set_encoding_layer` and `encoding_layer`
- decode from classifier using the dedicated layer
- update CLI encoding path to populate the new layer and avoid saving before training
- set encoding layer on the encode network itself

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6856487349288323bf0f9992bdcdb3ad