### PR TITLE
Allow training after encoding

### DIFF
--- a/streamz-rs/src/main.rs
+++ b/streamz-rs/src/main.rs
@@ -675,7 +675,7 @@ fn main() {
                 }
                 Err(e) => eprintln!("Encoding failed: {}", e),
             }
-            return;
+            // Continue with training after encoding
         }
     }
 


### PR DESCRIPTION
## Summary
- continue training the classifier after using `--encode`

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_685683e7713c832392eb68b101b46e8b